### PR TITLE
Extend type definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ npx better-supabase-types -i ./src/schema.ts -o ./src/newSchema.ts
 
 If you would like to overwrite the input file with the better types output, you must supply the `force` flag (`-f`) to the generate command:
 
-```
+```bash
 npx better-supabase-types -i ./src/schema.ts -f
 ```
 
@@ -34,7 +34,23 @@ If your project uses `prettier` this tool will automattically read it from your 
 npx better-supabase-types -i ./src/schema.ts -o ./src/newSchema.ts -p ./configs/.prettierrc.yaml
 ```
 
-### Before 📉:
+### Creating singular model type names from plural table names
+
+If you use the common naming pattern of having plural table names, it can be confusing when the model type is also a plural, as it gives the impression that it represents more than one record. You can ask `better-supabase-types` to transform the model type name into the singular form (using the `pluralize` library) with the `singular` flag (`-s`). By default this is set to false (turned off).
+
+```bash
+npx better-supabase-types -i ./src/schema.ts -o ./src/newSchema.ts -s
+```
+
+Example schema output with the `singular` flag turned on:
+
+```ts
+export type Account = Database['public']['Tables']['accounts']['Row'];
+export type InsertAccount = Database['public']['Tables']['accounts']['Insert'];
+export type UpdateAccount = Database['public']['Tables']['accounts']['Update'];
+```
+
+### Before 📉
 
 ```ts
 import { Database } from './src/schema.ts';
@@ -44,7 +60,7 @@ type Todo = Database['public']['Tables']['Todo']['Row'];
 const todos: Todo[] = [];
 ```
 
-### After 📈:
+### After 📈
 
 ```ts
 import { Todo } from './src/newSchema.ts';
@@ -52,14 +68,15 @@ import { Todo } from './src/newSchema.ts';
 const todos: Todo[] = [];
 ```
 
-### Config file ⚙:
+### Config file ⚙
 
 You can also use a config named `betterrc.json`:
 
 ```json
 {
   "input": "./src/schema.ts",
-  "force": true
+  "force": true,
+  "singular": true
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "bugs": "https://github.com/FroggyPanda/better-supabase-types/issues",
   "author": "FroggyPanda",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "private": false,
   "version": "2.2.0",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "private": false,
-  "version": "2.2.0",
+  "version": "2.3.0",
   "license": "MIT",
   "scripts": {
     "build": "tsc",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "better-supabase-types": "./dist/index.js"
   },
   "dependencies": {
+    "pluralize": "^8.0.0",
     "prettier": "^2.8.8",
     "ts-morph": "^18.0.0",
     "yargs": "^17.7.1",
@@ -24,6 +25,7 @@
   },
   "devDependencies": {
     "@types/node": "^18.15.13",
+    "@types/pluralize": "^0.0.29",
     "@types/prettier": "^2.7.2",
     "@types/yargs": "^17.0.24",
     "nodemon": "^2.0.22",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,6 +1,9 @@
 lockfileVersion: '6.0'
 
 dependencies:
+  pluralize:
+    specifier: ^8.0.0
+    version: 8.0.0
   prettier:
     specifier: ^2.8.8
     version: 2.8.8
@@ -18,6 +21,9 @@ devDependencies:
   '@types/node':
     specifier: ^18.15.13
     version: 18.15.13
+  '@types/pluralize':
+    specifier: ^0.0.29
+    version: 0.0.29
   '@types/prettier':
     specifier: ^2.7.2
     version: 2.7.2
@@ -107,6 +113,10 @@ packages:
 
   /@types/node@18.15.13:
     resolution: {integrity: sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==}
+    dev: true
+
+  /@types/pluralize@0.0.29:
+    resolution: {integrity: sha512-BYOID+l2Aco2nBik+iYS4SZX0Lf20KPILP5RGmM1IgzdwNdTs0eebiFriOPcej1sX9mLnSoiNte5zcFxssgpGA==}
     dev: true
 
   /@types/prettier@2.7.2:
@@ -415,6 +425,11 @@ packages:
   /picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
+
+  /pluralize@8.0.0:
+    resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
+    engines: {node: '>=4'}
+    dev: false
 
   /prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -1,7 +1,13 @@
 import fs from 'fs';
 import { getTablesProperties, prettierFormat, toPascalCase } from './utils';
 
-export async function generate(input: string, output: string, prettierConfigPath?: string, schemas: string[] = ['public'], makeSingular: boolean = false) {
+export async function generate(
+  input: string,
+  output: string,
+  prettierConfigPath?: string,
+  schemas: string[] = ['public'],
+  makeSingular: boolean = false
+) {
   const exists = fs.existsSync(input);
 
   if (!exists) {
@@ -9,25 +15,31 @@ export async function generate(input: string, output: string, prettierConfigPath
     return;
   }
 
-  const tablesProperties = schemas.flatMap((schema) => getTablesProperties(input, schema));
   const types: string[] = [];
 
-  for (const table of tablesProperties) {
-    const tableName = table.getName();
-    const tableNameType = toPascalCase(tableName, makeSingular);
+  for (const schema of schemas) {
+    const tablesProperties = getTablesProperties(input, schema);
 
-    types.push(
-      `export type ${tableNameType} = Database['public']['Tables']['${tableName}']['Row'];`,
-      `export type Insert${tableNameType} = Database['public']['Tables']['${tableName}']['Insert'];`,
-      `export type Update${tableNameType} = Database['public']['Tables']['${tableName}']['Update'];`,
-      '\n'
-    );
+    for (const table of tablesProperties) {
+      const tableName = table.getName();
+      const tableNameType = toPascalCase(tableName, makeSingular);
+
+      types.push(
+        `export type ${tableNameType} = Database['${schema}']['Tables']['${tableName}']['Row'];`,
+        `export type Insert${tableNameType} = Database['${schema}']['Tables']['${tableName}']['Insert'];`,
+        `export type Update${tableNameType} = Database['${schema}']['Tables']['${tableName}']['Update'];`,
+        '\n'
+      );
+    }
   }
 
   const fileContent = fs.readFileSync(input, 'utf-8');
   let updatedFileContent = fileContent + '\n' + types.join('\n') + '\n';
   if (prettierConfigPath) {
-    updatedFileContent = await prettierFormat(updatedFileContent, prettierConfigPath);
+    updatedFileContent = await prettierFormat(
+      updatedFileContent,
+      prettierConfigPath
+    );
   }
 
   fs.writeFileSync(output, updatedFileContent);

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { getTablesProperties, prettierFormat, toPascalCase } from './utils';
 
-export async function generate(input: string, output: string, prettierConfigPath?: string, schemas: string[] = ['public']) {
+export async function generate(input: string, output: string, prettierConfigPath?: string, schemas: string[] = ['public'], makeSingular: boolean = false) {
   const exists = fs.existsSync(input);
 
   if (!exists) {
@@ -14,7 +14,7 @@ export async function generate(input: string, output: string, prettierConfigPath
 
   for (const table of tablesProperties) {
     const tableName = table.getName();
-    const tableNameType = toPascalCase(tableName);
+    const tableNameType = toPascalCase(tableName, makeSingular);
 
     types.push(
       `export type ${tableNameType} = Database['public']['Tables']['${tableName}']['Row'];`,

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { getTablesProperties, prettierFormat, toPascalCase } from './utils';
 
-export async function generate(input: string, output: string, prettierConfigPath?: string) {
+export async function generate(input: string, output: string, prettierConfigPath?: string, schemas: string[] = ['public']) {
   const exists = fs.existsSync(input);
 
   if (!exists) {
@@ -9,7 +9,7 @@ export async function generate(input: string, output: string, prettierConfigPath
     return;
   }
 
-  const tablesProperties = getTablesProperties(input);
+  const tablesProperties = schemas.flatMap((schema) => getTablesProperties(input, schema));
   const types: string[] = [];
 
   for (const table of tablesProperties) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ if (configExists) {
       force: z.boolean().optional(),
       prettier: z.string().optional().default('.prettierrc'),
       schemas: z.array(z.string()).optional().default(['public']),
+      singular: z.boolean().optional().default(false),
     })
     .strict();
 
@@ -39,8 +40,9 @@ if (configExists) {
       const output = result.data.output || result.data.input;
       const prettier = result.data.prettier;
       const schemas = result.data.schemas;
+      const singular = result.data.singular ?? false;
 
-      generate(input, output, prettier, schemas);
+      generate(input, output, prettier, schemas, singular);
     }
   }
 } else if (packageJsonFile['betterConfig']) {
@@ -52,6 +54,7 @@ if (configExists) {
       force: z.boolean().optional(),
       prettier: z.string().optional().default('.prettierrc'),
       schemas: z.array(z.string()).optional().default(['public']),
+      singular: z.boolean().optional().default(false),
     })
     .strict();
 
@@ -69,8 +72,9 @@ if (configExists) {
       const output = result.data.output || result.data.input;
       const prettier = result.data.prettier;
       const schemas = result.data.schemas;
+      const singular = result.data.singular ?? false;
 
-      generate(input, output, prettier, schemas);
+      generate(input, output, prettier, schemas, singular);
     }
   }
 } else {
@@ -113,6 +117,13 @@ if (configExists) {
               requiresArg: false,
               default: ['public'],
             },
+            singular: {
+              type: 'boolean',
+              alias: ['sg'],
+              describe: 'Convert table names to singular form instead of plural form',
+              requiresArg: false,
+              default: false,
+            },
           })
           .demandOption(['input']);
       },
@@ -137,8 +148,9 @@ if (configExists) {
           }
           return acc;
         }, []);
+        const singular = argv.singular ?? false;
 
-        generate(input, output, prettier, schemas);
+        generate(input, output, prettier, schemas, singular);
       }
     )
     .help()

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,6 @@ if (configExists) {
       output: z.string().optional(),
       force: z.boolean().optional(),
       prettier: z.string().optional().default('.prettierrc'),
-      schemas: z.array(z.string()).optional().default(['public']),
       singular: z.boolean().optional().default(false),
     })
     .strict();
@@ -39,10 +38,9 @@ if (configExists) {
       const input = result.data.input;
       const output = result.data.output || result.data.input;
       const prettier = result.data.prettier;
-      const schemas = result.data.schemas;
       const singular = result.data.singular ?? false;
 
-      generate(input, output, prettier, schemas, singular);
+      generate(input, output, prettier, singular);
     }
   }
 } else if (packageJsonFile['betterConfig']) {
@@ -53,7 +51,6 @@ if (configExists) {
       output: z.string().optional(),
       force: z.boolean().optional(),
       prettier: z.string().optional().default('.prettierrc'),
-      schemas: z.array(z.string()).optional().default(['public']),
       singular: z.boolean().optional().default(false),
     })
     .strict();
@@ -71,10 +68,9 @@ if (configExists) {
       const input = result.data.input;
       const output = result.data.output || result.data.input;
       const prettier = result.data.prettier;
-      const schemas = result.data.schemas;
       const singular = result.data.singular ?? false;
 
-      generate(input, output, prettier, schemas, singular);
+      generate(input, output, prettier, singular);
     }
   }
 } else {
@@ -110,17 +106,11 @@ if (configExists) {
               alias: ['f'],
               describe: 'Force the overwrite of the input file',
             },
-            schemas: {
-              type: 'array',
-              alias: ['s'],
-              describe: 'List of schema names to include in the output',
-              requiresArg: false,
-              default: ['public'],
-            },
             singular: {
               type: 'boolean',
-              alias: ['sg'],
-              describe: 'Convert table names to singular form instead of plural form',
+              alias: ['s'],
+              describe:
+                'Convert table names to singular form instead of plural form',
               requiresArg: false,
               default: false,
             },
@@ -138,19 +128,9 @@ if (configExists) {
         const input = argv.input;
         const output = argv.output || argv.input;
         const prettier = argv.prettier;
-        const schemaArgs: (string|number)[] = argv.schemas;
-        const schemas = schemaArgs.reduce((acc: string[], schema: string|number): string[] => {
-          if (isString(schema)) {
-            acc.push(schema);
-          }
-          else {
-            acc.push(schema.toString());
-          }
-          return acc;
-        }, []);
         const singular = argv.singular ?? false;
 
-        generate(input, output, prettier, schemas, singular);
+        generate(input, output, prettier, singular);
       }
     )
     .help()

--- a/src/utils/getEnumsProperties.ts
+++ b/src/utils/getEnumsProperties.ts
@@ -1,0 +1,74 @@
+import {
+  LiteralTypeNode,
+  ModuleKind,
+  Project,
+  ScriptTarget,
+  ts,
+} from 'ts-morph';
+
+export function getEnumsProperties(typesPath: string, schema: string) {
+  const project = new Project({
+    compilerOptions: {
+      allowSyntheticDefaultImports: true,
+      esModuleInterop: true,
+      module: ModuleKind.ESNext,
+      target: ScriptTarget.ESNext,
+      strictNullChecks: true,
+    },
+  });
+
+  const sourceFile = project.addSourceFileAtPath(typesPath);
+
+  const databaseInterface = sourceFile.getInterfaceOrThrow('Database');
+  const publicProperty = databaseInterface.getPropertyOrThrow(schema);
+  const publicType = publicProperty.getType();
+
+  const enumsProperty = publicType
+    .getApparentProperties()
+    .find((property) => property.getName() === 'Enums');
+
+  if (!enumsProperty) {
+    console.log(
+      `No Enums property found within the Database interface for schema ${schema}.`
+    );
+    return [];
+  }
+
+  const enumsType = project
+    .getProgram()
+    .getTypeChecker()
+    .getTypeAtLocation(enumsProperty.getValueDeclarationOrThrow());
+  const enumsProperties = enumsType.getProperties();
+
+  if (enumsProperties.length < 1) {
+    console.log(
+      `No enums found within the Enums property for schema ${schema}.`
+    );
+    return [];
+  }
+
+  return enumsProperties;
+}
+
+function getEnumValueLabel(value: LiteralTypeNode) {
+  return value.getText().replace(/"/g, '').replace(/ /g, '_');
+}
+
+function getEnumValueText(value: LiteralTypeNode) {
+  return value.getText();
+}
+
+export function getEnumValuesText(
+  enumProperty: ReturnType<typeof getEnumsProperties>[number]
+) {
+  const enumValues = enumProperty
+    .getValueDeclarationOrThrow()
+    .getChildrenOfKind(ts.SyntaxKind.UnionType)
+    .flatMap((enumValue) =>
+      enumValue.getChildrenOfKind(ts.SyntaxKind.LiteralType)
+    );
+
+  return enumValues.map(
+    (value) => `  ${getEnumValueLabel(value)} = ${getEnumValueText(value)},`
+  );
+}

--- a/src/utils/getSchemasProperties.ts
+++ b/src/utils/getSchemasProperties.ts
@@ -1,0 +1,28 @@
+import { ModuleKind, Project, ScriptTarget } from 'ts-morph';
+
+export function getSchemasProperties(typesPath: string) {
+  const project = new Project({
+    compilerOptions: {
+      allowSyntheticDefaultImports: true,
+      esModuleInterop: true,
+      module: ModuleKind.ESNext,
+      target: ScriptTarget.ESNext,
+      strictNullChecks: true,
+    },
+  });
+
+  const sourceFile = project.addSourceFileAtPath(typesPath);
+
+  const databaseInterface = sourceFile.getInterfaceOrThrow('Database');
+
+  const schemasType = project
+    .getProgram()
+    .getTypeChecker()
+    .getTypeAtLocation(databaseInterface);
+  const schemasProperties = schemasType.getProperties();
+
+  if (schemasProperties.length < 1)
+    throw new Error('No schemas found within the Database property.');
+
+  return schemasProperties;
+}

--- a/src/utils/getTablesProperties.ts
+++ b/src/utils/getTablesProperties.ts
@@ -21,8 +21,12 @@ export function getTablesProperties(typesPath: string, schema: string) {
     .getApparentProperties()
     .find((property) => property.getName() === 'Tables');
 
-  if (!tablesProperty)
-    throw new Error('No Tables property found within the Database interface.');
+  if (!tablesProperty) {
+    console.log(
+      `No Tables property found within the Database interface for schema ${schema}.`
+    );
+    return [];
+  }
 
   const tablesType = project
     .getProgram()
@@ -30,8 +34,12 @@ export function getTablesProperties(typesPath: string, schema: string) {
     .getTypeAtLocation(tablesProperty.getValueDeclarationOrThrow());
   const tablesProperties = tablesType.getProperties();
 
-  if (tablesProperties.length < 1)
-    throw new Error('No tables found within the Tables property.');
+  if (tablesProperties.length < 1) {
+    console.log(
+      `No tables found within the Tables property for schema ${schema}.`
+    );
+    return [];
+  }
 
   return tablesProperties;
 }

--- a/src/utils/getTablesProperties.ts
+++ b/src/utils/getTablesProperties.ts
@@ -1,6 +1,6 @@
 import { ModuleKind, Project, ScriptTarget } from 'ts-morph';
 
-export function getTablesProperties(typesPath: string) {
+export function getTablesProperties(typesPath: string, schema: string) {
   const project = new Project({
     compilerOptions: {
       allowSyntheticDefaultImports: true,
@@ -14,7 +14,7 @@ export function getTablesProperties(typesPath: string) {
   const sourceFile = project.addSourceFileAtPath(typesPath);
 
   const databaseInterface = sourceFile.getInterfaceOrThrow('Database');
-  const publicProperty = databaseInterface.getPropertyOrThrow('public');
+  const publicProperty = databaseInterface.getPropertyOrThrow(schema);
   const publicType = publicProperty.getType();
 
   const tablesProperty = publicType

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,5 @@
+export * from './getEnumsProperties';
+export * from './getSchemasProperties';
 export * from './getTablesProperties';
 export * from './prettierFormat';
 export * from './toPascalCase';

--- a/src/utils/toPascalCase.ts
+++ b/src/utils/toPascalCase.ts
@@ -1,7 +1,14 @@
-export function toPascalCase(str: string) {
+import { singular } from 'pluralize';
+
+const wordToPascalCase = (makeSingular: boolean) => (word: string) => {
+  const singularWord = makeSingular ? singular(word) : word;
+  return singularWord.charAt(0).toUpperCase() + singularWord.substring(1);
+}
+
+export function toPascalCase(str: string, makeSingular: boolean = false) {
   return str
     .split('_')
-    .map(word => word.charAt(0).toUpperCase() + word.substring(1))
+    .map(wordToPascalCase(makeSingular))
     .join('');
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,10 @@
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "noUncheckedIndexedAccess": true
+    "noUncheckedIndexedAccess": true,
+    "declaration": true
   },
-  "include": ["./src/**/*.ts"]
+  "include": [
+    "./src/**/*.ts"
+  ]
 }


### PR DESCRIPTION
- Generate better-supbase-types typescript definition files when compiling dist
- Add ability to process more than one schema (retrieving schema names from the Database definition)
- Add opt-in ability to modify model type names from plurals to singular form - e.g. table `accounts` creates `type Account`
- Add creation of typescript enums matching enum types in the Database schema.