### PR TITLE
added type generation for function arguments and return types

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "private": false,
-  "version": "2.4.1",
+  "version": "2.6.0",
   "license": "MIT",
   "scripts": {
     "build": "tsup ./src/index.ts --format cjs,esm --dts",

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import {
   getEnumValuesText,
   getEnumsProperties,
+  getFunctionReturnTypes,
   getSchemasProperties,
   getTablesProperties,
   prettierFormat,
@@ -28,6 +29,7 @@ export async function generate(
     const schemaName = schema.getName();
     const tablesProperties = getTablesProperties(input, schemaName);
     const enumsProperties = getEnumsProperties(input, schemaName);
+    const functionProperties = getFunctionReturnTypes(input, schemaName);
 
     for (const enumProperty of enumsProperties) {
       const enumName = enumProperty.getName();
@@ -49,6 +51,16 @@ export async function generate(
         `export type ${tableNameType} = Database['${schemaName}']['Tables']['${tableName}']['Row'];`,
         `export type Insert${tableNameType} = Database['${schemaName}']['Tables']['${tableName}']['Insert'];`,
         `export type Update${tableNameType} = Database['${schemaName}']['Tables']['${tableName}']['Update'];`,
+        '\n'
+      );
+    }
+    for (const functionProperty of functionProperties) {
+      const functionName = functionProperty.getName();
+      const functionNameType = toPascalCase(functionName, makeSingular);
+
+      types.push(
+        `export type Args${functionNameType} = Database['${schemaName}']['Functions']['${functionName}']['Args'];`,
+        `export type ReturnType${functionNameType} = Database['${schemaName}']['Functions']['${functionName}']['Returns'];`,
         '\n'
       );
     }

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -26,11 +26,16 @@ export async function generate(
 
   const schemas = getSchemasProperties(input);
   for (const schema of schemas) {
+    types.push(`//Schema: ${schema.getName()}`);
+    
     const schemaName = schema.getName();
     const tablesProperties = getTablesProperties(input, schemaName);
     const enumsProperties = getEnumsProperties(input, schemaName);
     const functionProperties = getFunctionReturnTypes(input, schemaName);
 
+    if (enumsProperties.length > 0) {
+      types.push('//Enums');
+    }
     for (const enumProperty of enumsProperties) {
       const enumName = enumProperty.getName();
       const enumNameType = toPascalCase(enumName, makeSingular);
@@ -43,6 +48,9 @@ export async function generate(
       );
     }
 
+    if (tablesProperties.length > 0) {
+      types.push('//Tables');
+    }
     for (const table of tablesProperties) {
       const tableName = table.getName();
       const tableNameType = toPascalCase(tableName, makeSingular);
@@ -53,6 +61,10 @@ export async function generate(
         `export type Update${tableNameType} = Database['${schemaName}']['Tables']['${tableName}']['Update'];`,
         '\n'
       );
+    }
+
+    if (functionProperties.length > 0) {
+      types.push('//Functions');
     }
     for (const functionProperty of functionProperties) {
       const functionName = functionProperty.getName();

--- a/src/utils/getFunctionProperties.ts
+++ b/src/utils/getFunctionProperties.ts
@@ -1,0 +1,45 @@
+import { ModuleKind, Project, ScriptTarget } from 'ts-morph';
+
+export function getFunctionReturnTypes(typesPath: string, schema: string) {
+  const project = new Project({
+    compilerOptions: {
+      allowSyntheticDefaultImports: true,
+      esModuleInterop: true,
+      module: ModuleKind.ESNext,
+      target: ScriptTarget.ESNext,
+      strictNullChecks: true,
+    },
+  });
+
+  const sourceFile = project.addSourceFileAtPath(typesPath);
+
+  const databaseInterface = sourceFile.getInterfaceOrThrow('Database');
+  const publicProperty = databaseInterface.getPropertyOrThrow(schema);
+  const publicType = publicProperty.getType();
+
+  const functionProperty = publicType
+    .getApparentProperties()
+    .find((property) => property.getName() === 'Functions');
+
+  if (!functionProperty) {
+    console.log(
+      `No Functions property found within the Database interface for schema ${schema}.`
+    );
+    return [];
+  }
+
+  const functionType = project
+    .getProgram()
+    .getTypeChecker()
+    .getTypeAtLocation(functionProperty.getValueDeclarationOrThrow());
+  const functionProperties = functionType.getProperties();
+
+  if (functionProperties.length < 1) {
+    console.log(
+      `No functions found within the Functions property for schema ${schema}.`
+    );
+    return [];
+  }
+
+  return functionProperties;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,6 @@
 export * from './getEnumsProperties';
 export * from './getSchemasProperties';
 export * from './getTablesProperties';
+export * from './getFunctionProperties';
 export * from './prettierFormat';
 export * from './toPascalCase';


### PR DESCRIPTION
This PR adds function arguments and return types to the type generation process. Useful if you have Postgres functions with specific return types or arguments.
Additionally added some comments between the different schemas to enhance the readability of the outputted file.