### PR TITLE
Improve enums

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "private": false,
-  "version": "2.6.2",
+  "version": "2.6.3",
   "license": "MIT",
   "scripts": {
     "build": "tsup ./src/index.ts --format cjs,esm --dts",

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -15,7 +15,8 @@ export async function generate(
   input: string,
   output: string,
   prettierConfigPath?: string,
-  makeSingular: boolean = false
+  makeSingular: boolean = false,
+  enumAsType: boolean = false
 ) {
   const exists = fs.existsSync(input);
 
@@ -62,12 +63,21 @@ export async function generate(
       const enumName = enumProperty.getName();
       const enumNameType = toPascalCase(enumName, makeSingular);
 
-      types.push(
-        `export enum ${enumNameType} {`,
-        ...(getEnumValuesText(enumProperty) ?? []),
-        '}',
-        '\n'
-      );
+      if (enumAsType) {
+        types.push(
+          `export type ${enumNameType} = {`,
+          ...(getEnumValuesText(enumProperty, enumAsType) ?? []),
+          '}',
+          '\n'
+        );
+      } else {
+        types.push(
+          `export enum ${enumNameType} {`,
+          ...(getEnumValuesText(enumProperty, enumAsType) ?? []),
+          '}',
+          '\n'
+        );
+      }
     }
 
     if (tablesProperties.length > 0) {

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -62,21 +62,18 @@ export async function generate(
     }
     for (const enumProperty of enumsProperties) {
       const enumName = enumProperty.getName();
-      const enumNameType = toPascalCase(enumName, makeSingular);
+      const newEnumName = enumName.replace(/-/g, '_');
+      const enumNameType = toPascalCase(newEnumName, makeSingular);
 
       if (enumAsType) {
         types.push(
-          `export type ${enumNameType} = {`,
-          ...(getEnumValuesText(enumProperty, enumAsType, enumPascalCase) ??
-            []),
-          '}',
+          `export type ${enumNameType} = Database['${schemaName}']['Enums']['${enumName}'];`,
           '\n'
         );
       } else {
         types.push(
           `export enum ${enumNameType} {`,
-          ...(getEnumValuesText(enumProperty, enumAsType, enumPascalCase) ??
-            []),
+          ...(getEnumValuesText(enumProperty, enumPascalCase) ?? []),
           '}',
           '\n'
         );

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -16,7 +16,8 @@ export async function generate(
   output: string,
   prettierConfigPath?: string,
   makeSingular: boolean = false,
-  enumAsType: boolean = false
+  enumAsType: boolean = false,
+  enumPascalCase: boolean = false
 ) {
   const exists = fs.existsSync(input);
 
@@ -66,14 +67,16 @@ export async function generate(
       if (enumAsType) {
         types.push(
           `export type ${enumNameType} = {`,
-          ...(getEnumValuesText(enumProperty, enumAsType) ?? []),
+          ...(getEnumValuesText(enumProperty, enumAsType, enumPascalCase) ??
+            []),
           '}',
           '\n'
         );
       } else {
         types.push(
           `export enum ${enumNameType} {`,
-          ...(getEnumValuesText(enumProperty, enumAsType) ?? []),
+          ...(getEnumValuesText(enumProperty, enumAsType, enumPascalCase) ??
+            []),
           '}',
           '\n'
         );

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ const schema = z
     force: z.boolean().optional(),
     prettier: z.string().optional().default('.prettierrc'),
     singular: z.boolean().optional().default(false),
+    enumAsType: z.boolean().optional().default(false),
   })
   .strict();
 
@@ -38,8 +39,9 @@ if (configExists) {
       const output = result.data.output || result.data.input;
       const prettier = result.data.prettier;
       const singular = result.data.singular ?? false;
+      const enumAsType = result.data.enumAsType ?? false;
 
-      generate(input, output, prettier, singular);
+      generate(input, output, prettier, singular, enumAsType);
     }
   }
 } else if (packageJsonFile['betterConfig']) {
@@ -59,8 +61,9 @@ if (configExists) {
       const output = result.data.output || result.data.input;
       const prettier = result.data.prettier;
       const singular = result.data.singular ?? false;
+      const enumAsType = result.data.enumAsType ?? false;
 
-      generate(input, output, prettier, singular);
+      generate(input, output, prettier, singular, enumAsType);
     }
   }
 } else {
@@ -104,6 +107,12 @@ if (configExists) {
               requiresArg: false,
               default: false,
             },
+            enumAsType: {
+              type: 'boolean',
+              describe: 'Have converted enums defined as types and not enums',
+              requiresArg: false,
+              default: false,
+            },
           })
           .demandOption(['input']);
       },
@@ -119,8 +128,9 @@ if (configExists) {
         const output = argv.output || argv.input;
         const prettier = argv.prettier;
         const singular = argv.singular ?? false;
+        const enumAsType = argv.enumAsType ?? false;
 
-        generate(input, output, prettier, singular);
+        generate(input, output, prettier, singular, enumAsType);
       }
     )
     .help()

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ const schema = z
     prettier: z.string().optional().default('.prettierrc'),
     singular: z.boolean().optional().default(false),
     enumAsType: z.boolean().optional().default(false),
+    enumPascalCase: z.boolean().optional().default(false)
   })
   .strict();
 
@@ -40,8 +41,9 @@ if (configExists) {
       const prettier = result.data.prettier;
       const singular = result.data.singular ?? false;
       const enumAsType = result.data.enumAsType ?? false;
+      const enumPascalCase = result.data.enumPascalCase ?? false;
 
-      generate(input, output, prettier, singular, enumAsType);
+      generate(input, output, prettier, singular, enumAsType, enumPascalCase);
     }
   }
 } else if (packageJsonFile['betterConfig']) {
@@ -62,8 +64,9 @@ if (configExists) {
       const prettier = result.data.prettier;
       const singular = result.data.singular ?? false;
       const enumAsType = result.data.enumAsType ?? false;
+      const enumPascalCase = result.data.enumPascalCase ?? false;
 
-      generate(input, output, prettier, singular, enumAsType);
+      generate(input, output, prettier, singular, enumAsType, enumPascalCase);
     }
   }
 } else {
@@ -113,6 +116,12 @@ if (configExists) {
               requiresArg: false,
               default: false,
             },
+            enumPascalCase: {
+              type: 'boolean',
+              describe: 'Enums format to pascal case',
+              requiresArg: false,
+              default: false
+            }
           })
           .demandOption(['input']);
       },
@@ -129,8 +138,9 @@ if (configExists) {
         const prettier = argv.prettier;
         const singular = argv.singular ?? false;
         const enumAsType = argv.enumAsType ?? false;
+        const enumPascalCase = argv.enumPascalCase ?? false
 
-        generate(input, output, prettier, singular, enumAsType);
+        generate(input, output, prettier, singular, enumAsType, enumPascalCase);
       }
     )
     .help()

--- a/src/utils/getEnumsProperties.ts
+++ b/src/utils/getEnumsProperties.ts
@@ -1,6 +1,7 @@
 import { LiteralTypeNode, Project, SourceFile, ts } from 'ts-morph';
 import { toCamelCase } from './toCamelCase';
 import chalk from 'chalk';
+import { toPascalCase } from './toPascalCase';
 
 export function getEnumsProperties(
   project: Project,
@@ -42,7 +43,7 @@ export function getEnumsProperties(
   return enumsProperties;
 }
 
-function getEnumValueLabel(value: LiteralTypeNode) {
+function getEnumValueLabel(value: LiteralTypeNode, enumPascalCase: boolean) {
   let enumValue = value.getText().replace(/"/g, '');
   if (enumValue.includes(' ')) {
     enumValue.replace(/ /g, '_');
@@ -53,6 +54,11 @@ function getEnumValueLabel(value: LiteralTypeNode) {
   if (enumValue.includes('.')) {
     enumValue = toCamelCase(enumValue, '.');
   }
+  if (enumPascalCase) {
+    enumValue = enumValue.replace(/-/g,'_');
+    enumValue = `"${toPascalCase(enumValue.substring(1, enumValue.length - 1))}"`;
+  }
+    
   return enumValue;
 }
 
@@ -62,7 +68,8 @@ function getEnumValueText(value: LiteralTypeNode) {
 
 export function getEnumValuesText(
   enumProperty: ReturnType<typeof getEnumsProperties>[number],
-  enumAsType: boolean
+  enumAsType: boolean,
+  enumPascalCase: boolean
 ) {
   const enumValues = enumProperty
     .getValueDeclarationOrThrow()
@@ -73,11 +80,11 @@ export function getEnumValuesText(
 
   if (enumAsType) {
     return enumValues.map(
-    (value) => `  ${getEnumValueLabel(value)}: ${getEnumValueText(value)},`
+    (value) => `  ${getEnumValueLabel(value, enumPascalCase)}: ${getEnumValueText(value)},`
   );
   } else {
     return enumValues.map(
-    (value) => `  ${getEnumValueLabel(value)} = ${getEnumValueText(value)},`
+    (value) => `  ${getEnumValueLabel(value, enumPascalCase)} = ${getEnumValueText(value)},`
   );
   }
 }

--- a/src/utils/getEnumsProperties.ts
+++ b/src/utils/getEnumsProperties.ts
@@ -61,7 +61,8 @@ function getEnumValueText(value: LiteralTypeNode) {
 }
 
 export function getEnumValuesText(
-  enumProperty: ReturnType<typeof getEnumsProperties>[number]
+  enumProperty: ReturnType<typeof getEnumsProperties>[number],
+  enumAsType: boolean
 ) {
   const enumValues = enumProperty
     .getValueDeclarationOrThrow()
@@ -70,7 +71,13 @@ export function getEnumValuesText(
       enumValue.getChildrenOfKind(ts.SyntaxKind.LiteralType)
     );
 
-  return enumValues.map(
+  if (enumAsType) {
+    return enumValues.map(
+    (value) => `  ${getEnumValueLabel(value)}: ${getEnumValueText(value)},`
+  );
+  } else {
+    return enumValues.map(
     (value) => `  ${getEnumValueLabel(value)} = ${getEnumValueText(value)},`
   );
+  }
 }

--- a/src/utils/getEnumsProperties.ts
+++ b/src/utils/getEnumsProperties.ts
@@ -55,10 +55,12 @@ function getEnumValueLabel(value: LiteralTypeNode, enumPascalCase: boolean) {
     enumValue = toCamelCase(enumValue, '.');
   }
   if (enumPascalCase) {
-    enumValue = enumValue.replace(/-/g,'_');
-    enumValue = `"${toPascalCase(enumValue.substring(1, enumValue.length - 1))}"`;
+    enumValue = enumValue.replace(/-/g, '_');
+    enumValue = `"${toPascalCase(
+      enumValue.substring(1, enumValue.length - 1)
+    )}"`;
   }
-    
+
   return enumValue;
 }
 
@@ -68,7 +70,6 @@ function getEnumValueText(value: LiteralTypeNode) {
 
 export function getEnumValuesText(
   enumProperty: ReturnType<typeof getEnumsProperties>[number],
-  enumAsType: boolean,
   enumPascalCase: boolean
 ) {
   const enumValues = enumProperty
@@ -78,13 +79,10 @@ export function getEnumValuesText(
       enumValue.getChildrenOfKind(ts.SyntaxKind.LiteralType)
     );
 
-  if (enumAsType) {
-    return enumValues.map(
-    (value) => `  ${getEnumValueLabel(value, enumPascalCase)}: ${getEnumValueText(value)},`
+  return enumValues.map(
+    (value) =>
+      `  ${getEnumValueLabel(value, enumPascalCase)} = ${getEnumValueText(
+        value
+      )},`
   );
-  } else {
-    return enumValues.map(
-    (value) => `  ${getEnumValueLabel(value, enumPascalCase)} = ${getEnumValueText(value)},`
-  );
-  }
 }


### PR DESCRIPTION
Resolves #22 and #24

Use:
```bash
better-supabase-types -i input.ts -o output.ts --enumAsType --enumPascalCase
```

I hope I did this right as I did limited testing and not sure of all the possible ways enums could be typed out.