### PR TITLE
Included view types

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "private": false,
-  "version": "2.6.3",
+  "version": "2.7.0",
   "license": "MIT",
   "scripts": {
     "build": "tsup ./src/index.ts --format cjs,esm --dts",

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -5,6 +5,7 @@ import {
   getFunctionReturnTypes,
   getSchemasProperties,
   getTablesProperties,
+  getViewsProperties,
   prettierFormat,
   toPascalCase,
 } from './utils';
@@ -50,6 +51,11 @@ export async function generate(
       sourceFile,
       schemaName
     );
+    const viewsProperties = getViewsProperties(
+      project,
+      sourceFile,
+      schemaName
+    );
     const enumsProperties = getEnumsProperties(project, sourceFile, schemaName);
     const functionProperties = getFunctionReturnTypes(
       project,
@@ -91,6 +97,19 @@ export async function generate(
         `export type ${tableNameType} = Database['${schemaName}']['Tables']['${tableName}']['Row'];`,
         `export type Insert${tableNameType} = Database['${schemaName}']['Tables']['${tableName}']['Insert'];`,
         `export type Update${tableNameType} = Database['${schemaName}']['Tables']['${tableName}']['Update'];`,
+        '\n'
+      );
+    }
+
+    if (viewsProperties.length > 0) {
+      types.push('// Views');
+    }
+    for (const view of viewsProperties) {
+      const viewName = view.getName();
+      const viewNameType = toPascalCase(viewName, makeSingular);
+
+      types.push(
+        `export type ${viewNameType} = Database['${schemaName}']['Views']['${viewName}']['Row'];`,
         '\n'
       );
     }

--- a/src/utils/getViewsProperties.ts
+++ b/src/utils/getViewsProperties.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk';
 import { Project, SourceFile } from 'ts-morph';
 
 export function getViewsProperties(
@@ -15,7 +16,9 @@ export function getViewsProperties(
 
   if (!viewsProperty) {
     console.log(
-      `No Views property found within the Database interface for schema ${schema}.`
+      `${chalk.yellow.bold(
+        'warn'
+      )} No Views property found within the Database interface for schema ${schema}.`
     );
     return [];
   }

--- a/src/utils/getViewsProperties.ts
+++ b/src/utils/getViewsProperties.ts
@@ -1,0 +1,37 @@
+import { Project, SourceFile } from 'ts-morph';
+
+export function getViewsProperties(
+  project: Project,
+  sourceFile: SourceFile,
+  schema: string
+) {
+  const databaseInterface = sourceFile.getInterfaceOrThrow('Database');
+  const publicProperty = databaseInterface.getPropertyOrThrow(schema);
+  const publicType = publicProperty.getType();
+
+  const viewsProperty = publicType
+    .getApparentProperties()
+    .find((property) => property.getName() === 'Views');
+
+  if (!viewsProperty) {
+    console.log(
+      `No Views property found within the Database interface for schema ${schema}.`
+    );
+    return [];
+  }
+
+  const viewsType = project
+    .getProgram()
+    .getTypeChecker()
+    .getTypeAtLocation(viewsProperty.getValueDeclarationOrThrow());
+  const viewsProperties = viewsType.getProperties();
+
+  if (viewsProperties.length < 1) {
+    console.log(
+      `No views found within the Views property for schema ${schema}.`
+    );
+    return [];
+  }
+
+  return viewsProperties;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,7 @@
 export * from './getEnumsProperties';
 export * from './getSchemasProperties';
 export * from './getTablesProperties';
+export * from './getViewsProperties';
 export * from './getFunctionProperties';
 export * from './prettierFormat';
 export * from './toPascalCase';


### PR DESCRIPTION
Small feature to include view typing if views exist. Since views aren't necessarily included, I changed the warn console log to info in the getViewsProperties util.